### PR TITLE
Update uartRingBufDMA.c

### DIFF
--- a/UART CIRCULAR BUFFER/uartRingBufDMA.c
+++ b/UART CIRCULAR BUFFER/uartRingBufDMA.c
@@ -259,8 +259,8 @@ int getAfter (char *string, uint8_t numberofchars, char *buffertocopyinto, uint3
 	HAL_Delay (100);
 	for (int indx=0; indx<numberofchars; indx++)
 	{
-		if (Tail==MainBuf_SIZE) Tail = 0;
 		buffertocopyinto[indx] = MainBuf[Tail++];  // save the data into the buffer... increments the tail
+		if (Tail==MainBuf_SIZE) Tail = 0;
 	}
 	return 1;
 }


### PR DESCRIPTION
if (Tail==MainBuf_SIZE) Tail = 0;
Must be apply after Tail++ (or always before but all other functions are in this way except getAfter and this could cause crash if another function is called after getAfter and Tail = MainBuf_SIZE, MainBuf[MainBuf_SIZE] crashes