### PR TITLE
Making FLASH_SECTOR_H7.c compile for H723ZG

### DIFF
--- a/FLASH_PROGRAM/H7 SERIES/FLASH_SECTOR_H7.c
+++ b/FLASH_PROGRAM/H7 SERIES/FLASH_SECTOR_H7.c
@@ -214,11 +214,14 @@ uint32_t Flash_Write_Data (uint32_t StartSectorAddress, uint32_t *data, uint16_t
 	  EraseInitStruct.TypeErase     = FLASH_TYPEERASE_SECTORS;
 	  EraseInitStruct.VoltageRange  = FLASH_VOLTAGE_RANGE_3;
 	  EraseInitStruct.Sector        = StartSector;
+    EraseInitStruct.Banks         = FLASH_BANK_1;
 
-	  // The the proper BANK to erase the Sector
-	  if (StartSectorAddress < 0x08100000)
-		  EraseInitStruct.Banks     = FLASH_BANK_1;
-	  else EraseInitStruct.Banks    = FLASH_BANK_2;
+#ifdef DUAL_BANK
+    // The the proper BANK to erase the Sector
+    if (StartSectorAddress >= 0x08100000) {
+      EraseInitStruct.Banks = FLASH_BANK_2;
+    }
+#endif /* DUAL_BANK */
 
 	  EraseInitStruct.NbSectors     = (EndSector - StartSector) + 1;
 


### PR DESCRIPTION
The H723ZG board only has a `1` bank of FLASH memory; hence, the STM32 project compiler does not define `FLASH_BANK_2`, which makes the current code not compilable. This PR is a patch for fixing that.